### PR TITLE
atoi62: Fix the `underscoreOK` function

### DIFF
--- a/atoi62.go
+++ b/atoi62.go
@@ -47,6 +47,8 @@ func ParseUint(s string, base int, bitSize int) (uint64, error) {
 			d = c - 'a' + 10
 		case 'A' <= c && c <= 'Z':
 			d = c - 'A' + 10 + 26
+		case c == '_':
+			continue
 		default:
 			return 0, syntaxError(fnParseUint, s)
 		}
@@ -162,17 +164,15 @@ func underscoreOK(s string) bool {
 	}
 
 	// Optional base prefix.
-	hex := false
 	if len(s) >= 2 && s[0] == '0' && (lower(s[1]) == 'b' || lower(s[1]) == 'o' || lower(s[1]) == 'x') {
 		i = 2
 		saw = '0' // base prefix counts as a digit for "underscore as digit separator"
-		hex = lower(s[1]) == 'x'
 	}
 
 	// Number proper.
 	for ; i < len(s); i++ {
 		// Digits are always okay.
-		if '0' <= s[i] && s[i] <= '9' || hex && 'a' <= lower(s[i]) && lower(s[i]) <= 'f' {
+		if '0' <= s[i] && s[i] <= '9' || 'a' <= lower(s[i]) && lower(s[i]) <= 'z' {
 			saw = '0'
 			continue
 		}
@@ -184,14 +184,10 @@ func underscoreOK(s string) bool {
 			saw = '_'
 			continue
 		}
-		// Underscore must also be followed by digit.
-		if saw == '_' {
-			return false
-		}
 		// Saw non-digit, non-underscore.
-		saw = '!'
+		return false
 	}
-	return saw != '_'
+	return true
 }
 
 // Atoi is equivalent to ParseInt(s, 10, 0), converted to type int.


### PR DESCRIPTION
1. In the `ParseUint`, the `_` char is valid.
2. In the `underscoreOK`, if getting a `non-digit, non-underscore` char, it can return the `false` directly. And the `g-z` char is also valid. Because from the output of the `TestStrconv62`, the `base62` is `aZl8N0y58M7`.
`FormatInt: base10=9223372036854775807 -> base62=aZl8N0y58M7`